### PR TITLE
Geographic context for organizations (populate)

### DIFF
--- a/packages/core/system/public/gettext/de.json
+++ b/packages/core/system/public/gettext/de.json
@@ -78,5 +78,11 @@
     "Your query returned {{error.length}} entries, which is more than the allowed maximum of {{maxNodes}}. Please use the filter to restrict the number of results.": "Ihre Anfrage lieferte {{error.length}} Einträge. Das ist mehr als das erlaubte Maximum von {{maxNodes}}. Bitte verwenden Sie den Filter, um die Anzahl der Ergebnisse zu reduzieren. Geben Sie dazu einen Suchbegriff im Textfeld \"Filter\" ein."
     "Upload new organisation list": "Neue Liste der Organisationen hochladen",
     "Upload new zip-code list": "Neue Liste der Postleitzahlen hochladen"
-  }
+    "Federal State": "Bundesland",
+    "Carinthia": "Kärnten",
+    "Lower Austria": "Niederösterreich",
+    "Styria": "Steiermark",
+    "Tyrol": "Tirol",
+    "Upper Austria": "Oberösterreich",
+    "Vienna": "Wien"
 }

--- a/packages/core/system/public/gettext/translations.js
+++ b/packages/core/system/public/gettext/translations.js
@@ -78,7 +78,8 @@ angular.module('gettext').run(['gettextCatalog', function (gettextCatalog) {
         "Your are currently viewing the details of {{org.name}} together with a text filter. This limits the results! Please consider clearing the filter to see all money transfers of this organisation.": "Sie sehen gerade die Details für {{org.name}}, haben aber gleichzeitig einen Filter aktiviert. Dies limitiert die Anzeige. Löschen Sie den Eintrag im Filter-Feld um alle Zahlungen zu sehen.",
         "Your query returned {{error.length}} entries, which is more than the allowed maximum of {{maxNodes}}. Please use the filter to restrict the number of results.": "Ihre Anfrage lieferte {{error.length}} Einträge. Das ist mehr als das erlaubte Maximum von {{maxNodes}}. Bitte verwenden Sie den Filter, um die Anzahl der Ergebnisse zu reduzieren. Geben Sie dazu einen Suchbegriff im Textfeld \"Filter\" ein.",
         "Upload new organisation list": "Neue Liste der Organisationen hochladen",
-        "Upload new zip-code list": "Neue Liste der Postleitzahlen hochladen"
+        "Upload new zip-code list": "Neue Liste der Postleitzahlen hochladen",
+        "Federal State": "Bundesland"
     });
     /* jshint +W100 */
 }]);

--- a/packages/core/system/public/gettext/translations.js
+++ b/packages/core/system/public/gettext/translations.js
@@ -79,7 +79,13 @@ angular.module('gettext').run(['gettextCatalog', function (gettextCatalog) {
         "Your query returned {{error.length}} entries, which is more than the allowed maximum of {{maxNodes}}. Please use the filter to restrict the number of results.": "Ihre Anfrage lieferte {{error.length}} Einträge. Das ist mehr als das erlaubte Maximum von {{maxNodes}}. Bitte verwenden Sie den Filter, um die Anzahl der Ergebnisse zu reduzieren. Geben Sie dazu einen Suchbegriff im Textfeld \"Filter\" ein.",
         "Upload new organisation list": "Neue Liste der Organisationen hochladen",
         "Upload new zip-code list": "Neue Liste der Postleitzahlen hochladen",
-        "Federal State": "Bundesland"
+        "Federal State": "Bundesland",
+        "Carinthia": "Kärnten",
+        "Lower Austria": "Niederösterreich",
+        "Styria": "Steiermark",
+        "Tyrol": "Tirol",
+        "Upper Austria": "Oberösterreich",
+        "Vienna": "Wien",
     });
     /* jshint +W100 */
 }]);

--- a/packages/core/system/public/po/de.po
+++ b/packages/core/system/public/po/de.po
@@ -429,6 +429,11 @@ msgstr ""
 "Filter aktiviert. Dies limitiert die Anzeige. Löschen Sie den Eintrag im "
 "Filter-Feld um alle Zahlungen zu sehen."
 
+#: views/flow.html:42
+msgid ""
+"Federal State"
+msgstr ""
+"Bundesland"
 #: views/flow.html:63
 msgid ""
 "Your query returned {{error.length}} entries, which is more than the allowed "

--- a/packages/core/system/public/po/template.pot
+++ b/packages/core/system/public/po/template.pot
@@ -15,7 +15,7 @@ msgid "Although this was meant to significantly improve the data qualtity it cou
 msgstr ""
 
 #: controllers/flowController.js:13
-#: views/flow.html:86
+#: views/flow.html:97
 msgid "Amount"
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Click on a segment of the pie chart to get more information on a particular organization"
 msgstr ""
 
-#: views/flow.html:67
+#: views/flow.html:78
 msgid "Click on the rectangular boxes on either side of the chart to get more information on a particular organization"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "Contact Person"
 msgstr ""
 
-#: controllers/flowController.js:134
+#: controllers/flowController.js:169
 msgid "Display _MENU_ records"
 msgstr ""
 
@@ -76,6 +76,10 @@ msgstr ""
 msgid ""
 "FH Joanneum Gesellschaft mbH is not liable for the correctness of data provided by KommAustria. FH Joanneum Gesellschaft mbH stores and processes this raw data in order to facilitate the process of information extraction.\n"
 "        We are not liable for the interruption of service (eg. in cases of server down-time), data-errors, incorrect representation of data or software errors."
+msgstr ""
+
+#: views/flow.html:42
+msgid "Federal State"
 msgstr ""
 
 #: views/index.html:33
@@ -141,7 +145,7 @@ msgid "Loading Data to Update Diagram ..."
 msgstr ""
 
 #: controllers/flowController.js:10
-#: views/flow.html:83
+#: views/flow.html:94
 msgid "Media"
 msgstr ""
 
@@ -186,7 +190,7 @@ msgstr ""
 msgid "Organisation"
 msgstr ""
 
-#: views/flow.html:84
+#: views/flow.html:95
 msgid "Organisations"
 msgstr ""
 
@@ -199,7 +203,7 @@ msgid "Overview"
 msgstr ""
 
 #: controllers/flowController.js:12
-#: views/flow.html:85
+#: views/flow.html:96
 msgid "Payment Type"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: controllers/flowController.js:133
+#: controllers/flowController.js:168
 msgid "Showing page _PAGE_ of _PAGES_"
 msgstr ""
 
@@ -268,7 +272,7 @@ msgstr ""
 msgid "Spender/Recipient"
 msgstr ""
 
-#: views/flow.html:77
+#: views/flow.html:88
 msgid "Tabular Representation"
 msgstr ""
 
@@ -323,6 +327,7 @@ msgstr ""
 #: views/uploadZipCode.html:3
 msgid "Upload new zip-code list"
 msgstr ""
+
 #: views/index.html:43
 #: views/index.html:51
 #: views/index.html:59
@@ -339,18 +344,26 @@ msgstr ""
 msgid "Who's involved?"
 msgstr ""
 
-#: views/flow.html:59
+#: views/flow.html:70
 msgid "Your are currently viewing the details of {{org.name}} together with a text filter. This limits the results! Please consider clearing the filter to see all money transfers of this organisation."
 msgstr ""
 
-#: views/flow.html:63
+#: views/flow.html:74
 msgid "Your query returned {{error.length}} entries, which is more than the allowed maximum of {{maxNodes}}. Please use the filter to restrict the number of results."
 msgstr ""
 
-#: controllers/flowController.js:131
+#: controllers/flowController.js:166
 msgid "next"
 msgstr ""
 
-#: controllers/flowController.js:130
+#: controllers/flowController.js:165
 msgid "previous"
+msgstr ""
+
+#: views/flow.html:53
+msgid ""
+"{{org.name}}<br>\n"
+"                {{org.street}}<br>\n"
+"                {{org.zipCode}} {{org.city}}<br>\n"
+"                {{org.country}}<br>"
 msgstr ""

--- a/packages/custom/transparency/coffee/public/controllers/flowController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/flowController.coffee
@@ -125,6 +125,10 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
         $scope.org = {}
         $scope.org.name = node.name
         $scope.org.orgType = if node.type is 'o' then 'org' else 'media'
+        $scope.org.street = node.addressData.street
+        $scope.org.zipCode = node.addressData.zipCode
+        $scope.org.city = node.addressData.city_de
+        $scope.org.country = node.addressData.country_de
         update()
         window.scrollTo 0,0
 
@@ -176,6 +180,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
                 nodeMap[entry.organisation] =
                     index: nodesNum
                     type: 'o'
+                    addressData: entry.organisationReference
                 nodesNum++
             if not nodeMap[entry.media]?
                 nodeMap[entry.media] =
@@ -188,8 +193,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
                 value: entry.amount
                 type: entry.transferType
             )
-
-        nodes = Object.keys(nodeMap).map (k) -> name: k, type: nodeMap[k].type
+        nodes = Object.keys(nodeMap).map (k) -> name: k, type: nodeMap[k].type, addressData: nodeMap[k].addressData
         {nodes: nodes,links: links}
 
 

--- a/packages/custom/transparency/coffee/public/controllers/flowController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/flowController.coffee
@@ -57,7 +57,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
     #Variables for the selection of federalState
     $scope.selectedFederalState = '-'
     $scope.federalState = {}
-    $scope.federalStates = [{name: 'Burgenland'}, {name: 'Kärnten'}, {name: 'Niederösterreich'}, {name: 'Oberösterreich'}, {name: 'Salzburg'}, {name: 'Steiermark'}, {name: 'Tirol'}, {name: 'Vorarlberg'}, {name: 'Wien'}]
+    $scope.federalStates =  (name: gettextCatalog.getString(state.value), value: state.value for state in TPAService.staticData 'federal')
     $scope.flows =
         nodes: []
         links: []
@@ -66,7 +66,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
         params.maxLength = $scope.maxNodes
         params.from = $scope.periods[$scope.slider.from/5].period
         params.to = $scope.periods[$scope.slider.to/5].period
-        (params.federalState = $scope.selectedFederalState.name) if $scope.selectedFederalState
+        (params.federalState = $scope.selectedFederalState.value) if $scope.selectedFederalState
         types = (v.type for v in $scope.typesText when v.checked)
         (params.pType = types) if types.length > 0
         (params.filter = $scope.filter) if $scope.filter.length >= 3
@@ -117,6 +117,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
 
     translate = ->
         $scope.typesText.forEach (t) -> t.text = gettextCatalog.getString TPAService.decodeType t.type
+        $scope.federalStates.forEach (state) -> state.name = gettextCatalog.getString state.value
 
     $scope.$on 'gettextLanguageChanged', translate
 

--- a/packages/custom/transparency/coffee/public/controllers/flowController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/flowController.coffee
@@ -54,6 +54,10 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
     types = [2,4,31]
     $scope.typesText = (type:type,text: gettextCatalog.getString(TPAService.decodeType(type)),checked:false for type in types)
     $scope.typesText[0].checked = true
+    #Variables for the selection of federalState
+    $scope.selectedFederalState = '-'
+    $scope.federalState = {}
+    $scope.federalStates = [{name: 'Burgenland'}, {name: 'Kärnten'}, {name: 'Niederösterreich'}, {name: 'Oberösterreich'}, {name: 'Salzburg'}, {name: 'Steiermark'}, {name: 'Tirol'}, {name: 'Vorarlberg'}, {name: 'Wien'}]
     $scope.flows =
         nodes: []
         links: []
@@ -62,6 +66,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
         params.maxLength = $scope.maxNodes
         params.from = $scope.periods[$scope.slider.from/5].period
         params.to = $scope.periods[$scope.slider.to/5].period
+        (params.federalState = $scope.selectedFederalState.name) if $scope.selectedFederalState
         types = (v.type for v in $scope.typesText when v.checked)
         (params.pType = types) if types.length > 0
         (params.filter = $scope.filter) if $scope.filter.length >= 3
@@ -103,6 +108,7 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
         $scope.org = {} if $state.params.name or $state.params.orgType
         $scope.org.name = $state.params.name if $state.params.name
         $scope.org.orgType = $state.params.orgType if $state.params.orgType
+        $scope.selectedFederalState = $state.selectedFederalState if $state.selectedFederalState
         $scope.slider.from = $scope.periods.map((p) -> p.period).indexOf(parseInt $state.params.from)*5 if $state.params.from
         $scope.slider.to = $scope.periods.map((p) -> p.period).indexOf(parseInt $state.params.to)*5 if $state.params.to
         if $state.params.pTypes?
@@ -211,4 +217,5 @@ app.controller 'FlowCtrl',['$scope','TPAService','$q','$interval','$state','gett
         #$scope.$watch('slider.from',change,true)
         #$scope.$watch('slider.to',change,true)
         $scope.$watch('typesText',change,true)
+        $scope.$watch('selectedFederalState',change,true)
 ]

--- a/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
@@ -49,7 +49,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
                 sum + entry.total
             0
         )
-        $scope.pieData.push {key: gettextCatalog.getString("Others"), y: $scope.top.all - topSum} if not $scope.selectedFederalState
+        $scope.pieData.push {key: gettextCatalog.getString("Others"), y: $scope.top.all - topSum}
 
     $scope.toolTipContentFunction = (e) ->
         link = if e.index < $scope.rank then "<br/>"+gettextCatalog.getString("Click for Details") else ""

--- a/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
@@ -19,6 +19,8 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
     $scope.ranks = [3, 5, 10, 15, 20]
     $scope.rank = 10
     $scope.pieData = []
+    $scope.federalState = {}
+    $scope.federalStates = [{name: 'Burgenland'}, {name: 'Kärnten'}, {name: 'Niederösterreich'}, {name: 'Oberösterreich'}, {name: 'Salzburg'}, {name: 'Steiermark'}, {name: 'Tirol'}, {name: 'Vorarlberg'}, {name: 'Wien'}]
     window.scrollTo 0, 0
 
     # register watches to update chart when changes occur
@@ -26,6 +28,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
         $scope.$watch('typesText', change, true)
         $scope.$watch('orgType', change, true)
         $scope.$watch('rank', change, true)
+        $scope.$watch('selectedFederalState', change, true)
 
 
     #construct the query parameters
@@ -33,6 +36,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
         params = {}
         params.from = $scope.periods[$scope.slider.from/5].period
         params.to =$scope.periods[$scope.slider.to/5].period
+        (params.federalState = $scope.selectedFederalState.name) if $scope.selectedFederalState
         types = (v.type for v in $scope.typesText when v.checked)
         (params.pType = types) if types.length > 0
         params.x = $scope.rank
@@ -47,7 +51,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
                 sum + entry.total
             0
         )
-        $scope.pieData.push {key: gettextCatalog.getString("Others"), y: $scope.top.all - topSum}
+        $scope.pieData.push {key: gettextCatalog.getString("Others"), y: $scope.top.all - topSum} if not $scope.selectedFederalState
 
     $scope.toolTipContentFunction = (e) ->
         link = if e.index < $scope.rank then "<br/>"+gettextCatalog.getString("Click for Details") else ""
@@ -91,6 +95,8 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
             types = [2, 4, 31]
             $scope.typesText = (type: type, text: gettextCatalog.getString( TPAService.decodeType(type) ), checked: false for type in types)
             $scope.typesText[0].checked = true
+            #Variables for the selection of federalState
+            $scope.selectedFederalState = '-'
             $scope.orgType = $scope.orgTypes[0].value
             $q.all([pY, pP]).then (res) ->
                 update()

--- a/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
+++ b/packages/custom/transparency/coffee/public/controllers/topEntriesController.coffee
@@ -19,8 +19,6 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
     $scope.ranks = [3, 5, 10, 15, 20]
     $scope.rank = 10
     $scope.pieData = []
-    $scope.federalState = {}
-    $scope.federalStates = [{name: 'Burgenland'}, {name: 'Kärnten'}, {name: 'Niederösterreich'}, {name: 'Oberösterreich'}, {name: 'Salzburg'}, {name: 'Steiermark'}, {name: 'Tirol'}, {name: 'Vorarlberg'}, {name: 'Wien'}]
     window.scrollTo 0, 0
 
     # register watches to update chart when changes occur
@@ -36,7 +34,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
         params = {}
         params.from = $scope.periods[$scope.slider.from/5].period
         params.to =$scope.periods[$scope.slider.to/5].period
-        (params.federalState = $scope.selectedFederalState.name) if $scope.selectedFederalState
+        (params.federalState = $scope.selectedFederalState.value) if $scope.selectedFederalState
         types = (v.type for v in $scope.typesText when v.checked)
         (params.pType = types) if types.length > 0
         params.x = $scope.rank
@@ -76,6 +74,9 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
             {name: gettextCatalog.getString('Spender'), value: 'org'},
             {name: gettextCatalog.getString('Recipient'), value: 'media'}
         ]
+        #Federal states selection
+        $scope.federalState = {}
+        $scope.federalStates  =  (name: gettextCatalog.getString(state.value), value: state.value for state in TPAService.staticData 'federal')
         savedState = sessionStorage.getItem 'topState'
         if savedState
             TPAService.restoreState stateName, fieldsToStore, $scope
@@ -106,6 +107,7 @@ app.controller 'TopEntriesCtrl', ['$scope', 'TPAService', '$q', '$state','gettex
         $scope.orgTypes[0].name = gettextCatalog.getString('Spender')
         $scope.orgTypes[1].name = gettextCatalog.getString('Recipient')
         $scope.typesText.forEach (t) -> t.text = gettextCatalog.getString TPAService.decodeType t.type
+        $scope.federalStates.forEach (state) -> state.name = gettextCatalog.getString state.value
 
     $scope.$on 'gettextLanguageChanged', translate
 

--- a/packages/custom/transparency/coffee/public/services/transparencyService.coffee
+++ b/packages/custom/transparency/coffee/public/services/transparencyService.coffee
@@ -47,6 +47,21 @@ class TPAService
         when 4 then "Payments according to §4 MedKF-TG (Funding)"
         when 31 then "Payments according to §31 ORF-G (Charges)"
 
+    #Function to define static data, e.g. federal states
+    staticData: (type)->
+        switch type
+            when 'federal'
+                [
+                    {name: 'Burgenland',value: 'Burgenland'}
+                    {name: 'Carinthia', value: 'Carinthia' }
+                    {name: 'Lower Austria', value: 'Lower Austria' }
+                    {name: 'Salzburg', value: 'Salzburg' }
+                    {name: 'Styria', value: 'Styria' }
+                    {name: 'Tyrol',  value: 'Tyrol' }
+                    {name: 'Upper Austria',  value: 'Upper Austria' }
+                    {name: 'Vienna',  value: 'Vienna' }
+                    {name: 'Vorarlberg',  value: 'Vorarlberg' }
+                ]
 
 app = angular.module 'mean.transparency'
 app.service 'TPAService', ["$http", TPAService]

--- a/packages/custom/transparency/coffee/server/controllers/transparencyServerCtrl.coffee
+++ b/packages/custom/transparency/coffee/server/controllers/transparencyServerCtrl.coffee
@@ -22,7 +22,7 @@ regex = /"?(.+?)"?;(\d{4})(\d);(\d{1,2});\d;"?(.+?)"?;(\d+(?:,\d{1,2})?).*/
 mediaToFederalState = (mediaResult, limit, federalState) ->
     #Show only media from organisations within the federalState
     if federalState.length
-        mediaResult =  (media for media in mediaResult when media.organisationReference.federalState_de is federalState)
+        mediaResult =  (media for media in mediaResult when media.organisationReference.federalState_en is federalState)
 
     uniqueMedia= []
     #console.log("Entries in result " +mediaResult.length)
@@ -92,7 +92,7 @@ lineToOrganisation = (line, numberOfOrganisations) ->
         Q.all(findFederalState)
         .then (results) ->
             try
-                organisation.federalState_de = results.federalState
+                organisation.federalState_en = results.federalState
                 organisation.save()
             catch error
                 console.log error
@@ -296,9 +296,9 @@ module.exports = (Transparency) ->
                    .then(
                      (isPopulated) ->
                          if federalState
-                            #console.log "Federal State: " + transfer.organisationReference.federalState_de for transfer in result when transfer.organisationReference.federalState_de is federalState
+                            #console.log "Federal State: " + transfer.organisationReference.federalState_en for transfer in result when transfer.organisationReference.federalState_en is federalState
                             #create new results based on the federalState selection
-                            result = (transfer for transfer in result when transfer.organisationReference.federalState_de is federalState)
+                            result = (transfer for transfer in result when transfer.organisationReference.federalState_en is federalState)
                             #console.log("Result with " +federalState+" has length of " + result.length)
                             #console.log(JSON.stringify(result))
 
@@ -371,7 +371,7 @@ module.exports = (Transparency) ->
                             if orgType is 'org'
                                 if federalState.length
                                     #create new results based on the federalState selection
-                                    promiseResults[0] = (transfer for transfer in promiseResults[0] when transfer.organisationReference.federalState_de is federalState)
+                                    promiseResults[0] = (transfer for transfer in promiseResults[0] when transfer.organisationReference.federalState_en is federalState)
                                     #console.log("Result with " +federalState+" has length of " + result.length)
                                     #console.log ("we have to cut the array to the limit of " + results)
                                 topResult = promiseResults[0].splice(0,results);

--- a/packages/custom/transparency/coffee/server/controllers/transparencyServerCtrl.coffee
+++ b/packages/custom/transparency/coffee/server/controllers/transparencyServerCtrl.coffee
@@ -84,7 +84,7 @@ lineToTransfer = (line, feedback) ->
             try
                 if results.name
                     transfer.organisationReference = results._id
-                    console.log transfer.organisationReference
+                    #console.log transfer.organisationReference
                 transfer.save()
             catch error
                 console.log error
@@ -258,36 +258,27 @@ module.exports = (Transparency) ->
             )
             .exec()
             .then (result) ->
-                if federalState.length
-                    #console.log('Populate for federal state: ' + federalState);
-                    #path: what to look for
-                    Organisation.populate(result, {path: 'organisationReference'})
+                    #populate;
+                    #path: what to look for, select without id
+                    Organisation.populate(result, {path: 'organisationReference', select: '-_id'})
                     .then (
                         (err) ->
                             console.log "Error during populate: :" + err
                         (isPopulated) ->
-                            #console.log "Federal State: " + transfer.organisationReference.federalState_de for transfer in result when transfer.organisationReference.federalState_de is federalState
-                            #create new results based on the federalState selection
-                            federalStateResult = (transfer for transfer in result when transfer.organisationReference.federalState_de is federalState)
-                            #console.log("Result with " +federalState+" has length of " + federalStateResult.length)
-                            #console.log(JSON.stringify(federalStateResult))
-                            if federalStateResult.length > maxLength
+                            if federalState
+                                #console.log "Federal State: " + transfer.organisationReference.federalState_de for transfer in result when transfer.organisationReference.federalState_de is federalState
+                                #create new results based on the federalState selection
+                                result = (transfer for transfer in result when transfer.organisationReference.federalState_de is federalState)
+                                #console.log("Result with " +federalState+" has length of " + result.length)
+                                #console.log(JSON.stringify(result))
+                            if  result.length > maxLength
                                 res.status(413).send {
-                                    error: "You federal state query returns more then the specified maximum of #{maxLength}"
-                                    length: federalStateResult.length
+                                    error: "You query returns more then the specified maximum of #{maxLength}"
+                                    length: result.length
                                     }
                             else
-                                res.json federalStateResult
+                                res.json result
                     )
-                else
-                    if  result.length > maxLength
-                        res.status(413).send {
-                            error: "You query returns more then the specified maximum of #{maxLength}"
-                            length: result.length
-                        }
-                    else
-                        res.json result
-
             .catch (err) ->
                 res.status(500).send error: "Could not load money flow: #{err}"
         catch error

--- a/packages/custom/transparency/coffee/server/models/organisation.coffee
+++ b/packages/custom/transparency/coffee/server/models/organisation.coffee
@@ -22,6 +22,10 @@ OrganisationSchema = new Schema
         type: String
         trim: true
         required: true
+    federalState_de:
+        type: String
+        trim: true
+        required: true
     country_de:
         type: String
         trim: true
@@ -32,10 +36,7 @@ OrganisationSchema = new Schema
 OrganisationSchema.index(
   {
       name: 1
-      street: 1
-      zipCode: 1
-      city_de: 1
-      country_de: 1
+      federalState_de: 1
   },{
       unique: true
   }

--- a/packages/custom/transparency/coffee/server/models/organisation.coffee
+++ b/packages/custom/transparency/coffee/server/models/organisation.coffee
@@ -22,7 +22,7 @@ OrganisationSchema = new Schema
         type: String
         trim: true
         required: true
-    federalState_de:
+    federalState_en:
         type: String
         trim: true
         required: true
@@ -36,7 +36,7 @@ OrganisationSchema = new Schema
 OrganisationSchema.index(
   {
       name: 1
-      federalState_de: 1
+      federalState_en: 1
   },{
       unique: true
   }

--- a/packages/custom/transparency/coffee/server/models/transfer.coffee
+++ b/packages/custom/transparency/coffee/server/models/transfer.coffee
@@ -19,6 +19,9 @@ TransferSchema = new Schema
     year: Number
     quarter: Number
     period: Number
+    organisationReference:
+        type:Schema.Types.ObjectId
+        ref: 'Organisation'
 
 TransferSchema.path('transferType').validate(
     (transferType) -> transferType in [2,4,31]

--- a/packages/custom/transparency/public/views/flow.html
+++ b/packages/custom/transparency/public/views/flow.html
@@ -48,7 +48,7 @@
 
             </div>
         </div>
-        <div ng-show="org">
+        <div ng-show="org.street">
             <h3><a href="#" class="label label-success" ng-click="clearDetails()">{{org.name}} <span class="glyphicon glyphicon-remove-circle"></span></a></h3>
             <p translate="no">
                 {{org.name}}<br>

--- a/packages/custom/transparency/public/views/flow.html
+++ b/packages/custom/transparency/public/views/flow.html
@@ -28,7 +28,7 @@
                         <p class="small text-info" translate>Move the sliders to define a range</p>
 
                     </div>
-                    <div class="col-sm-6 col-lg-6">
+                    <div class="col-sm3 col-lg-3">
                         <strong><div translate>Payment Types</div></strong>
                         <div class="checkbox" data-ng-repeat="pType in typesText">
                             <label>
@@ -38,13 +38,24 @@
                         </div>
 
                     </div>
-
+                    <div class="col-sm3 col-lg-3">
+                        <strong><div translate>Federal State</div></strong>
+                       <select ng-model="selectedFederalState" ng-options="state.name for state in federalStates" name="federalStateSelect" id="federalStateSelect" >
+                           <option value="">-</option>
+                       </select>
+                    </div>
                 </div>
 
             </div>
         </div>
         <div ng-show="org">
             <h3><a href="#" class="label label-success" ng-click="clearDetails()">{{org.name}} <span class="glyphicon glyphicon-remove-circle"></span></a></h3>
+            <p translate="no">
+                {{org.name}}<br>
+                {{org.street}}<br>
+                {{org.zipCode}} {{org.city}}<br>
+                {{org.country}}<br>
+            </p>
         </div>
         <div class="text-center query bg-primary">
             <div class="btn-group">

--- a/packages/custom/transparency/public/views/top.html
+++ b/packages/custom/transparency/public/views/top.html
@@ -36,6 +36,10 @@
                             </label>
                         </div>
 
+                        <strong><div translate>Federal State</div></strong>
+                        <select ng-model="selectedFederalState" ng-options="state.name for state in federalStates" name="federalStateSelect" id="federalStateSelect" >
+                            <option value="">-</option>
+                        </select>
                     </div>
                     <div class="col-sm-1 col-lg-1">
                         <div translate>Top</div>


### PR DESCRIPTION
The pull request connects to #18 and connects to #47 

After the upload of organisation data and the identification of the federal state, it is now possible to select by federal state (top and flow). Therefore, the MongoDB approach of populate was used. One query allows to aggregate all needed values; another query is used for the “lookup” of the organisation. Within that query, all additionally operations (reducing, limit, counting…) are done.  
